### PR TITLE
aes_string() change to aes()

### DIFF
--- a/R/plot_bbdml.R
+++ b/R/plot_bbdml.R
@@ -121,7 +121,7 @@ plot.bbdml <- function(x, total = FALSE, color = NULL, shape = NULL, facet = NUL
 
   ylab_tmp <- ifelse(!total, "Relative Abundance", "Total Counts")
 
-  aes_map <- ggplot2::aes_string(x = "order", y = "RA", colour = color, shape = shape, labs = "samples")
+  aes_map <- ggplot2::aes(x = .data[["order"]], y = .data[["RA"]], colour = color, shape = shape, labs = "samples")
   my_gg <- ggplot2::ggplot(df, aes_map) +
     ggplot2::geom_point() +
     ggplot2::geom_errorbar(ggplot2::aes(ymin = ymin, ymax = ymax), width = .2) +


### PR DESCRIPTION
Changed line 124 on R/plot_bbdml.R from

aes_map <- ggplot2::aes_string(x = "order", y = "RA", colour = color, shape = shape, labs = "samples")

to its aes() version

aes_map <- ggplot2::aes(x = .data[["order"]], y = .data[["RA"]], colour = color, shape = shape, labs = "samples")

in order to address the warning on test_s3() regarding aes_string() deprecated in ggplot2

This addresses issue #158 