### PR TITLE
Update README and vignette to reflect installation via github instead of cran 

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ Count Regression for Correlated Observations with the Beta-binomial
 `corncob` is an `R` package for modeling relative abundance and testing hypotheses about the effect of covariates on relative abundance. The `corncob` methodology was specifically developed for modelling microbial abundances based on high throughput sequencing data, such as 16S or whole-genome sequencing.
 
 <!-- badges: start -->
-[![CRAN status](https://www.r-pkg.org/badges/version/corncob)](https://CRAN.R-project.org/package=corncob)
 [![R-CMD-check](https://github.com/statdivlab/CORNCOB/workflows/R-CMD-check/badge.svg)](https://github.com/statdivlab/CORNCOB/actions)
 [![codecov](https://codecov.io/github/statdivlab/corncob/coverage.svg?branch=main)](https://app.codecov.io/github/statdivlab/corncob)
 [![Docker Repository on Quay](https://quay.io/repository/fhcrc-microbiome/corncob/status "Docker Repository on Quay")](https://quay.io/repository/fhcrc-microbiome/corncob)
@@ -13,18 +12,11 @@ Count Regression for Correlated Observations with the Beta-binomial
 
 ## Installation
 
-To download the corncob package, use the code below.
+To install the `corncob` package, use the code below to download the development version from Github.
 
 ``` r
-install.packages("corncob")
-library(corncob)
-```
-
-Alternatively, you can install the development version directly from GitHub.
-
-``` r
-# install.packages("devtools")
-devtools::install_github("statdivlab/corncob")
+# install.packages("remotes")
+remotes::install_github("statdivlab/corncob")
 library(corncob)
 ```
 

--- a/man/contrastsTest.Rd
+++ b/man/contrastsTest.Rd
@@ -71,5 +71,5 @@ da_analysis <- contrastsTest(formula = ~ DayAmdmt,
                                                  "DayAmdmt22 - DayAmdmt21"),
                              data = soil_phylum_small_contrasts,
                              fdr_cutoff = 0.05,
-                             try_only = 5)
+                             try_only = 1:5)
 }

--- a/man/differentialTest.Rd
+++ b/man/differentialTest.Rd
@@ -92,5 +92,6 @@ da_analysis <- differentialTest(formula = ~ DayAmdmt,
                                 phi.formula_null = ~ DayAmdmt,
                                 test = "Wald", boot = FALSE,
                                 data = soil_phylum_small,
-                                fdr_cutoff = 0.05)
+                                fdr_cutoff = 0.05,
+                                try_only = 1:5)
 }

--- a/man/plot.differentialTest.Rd
+++ b/man/plot.differentialTest.Rd
@@ -30,7 +30,8 @@ da_analysis <- differentialTest(formula = ~ DayAmdmt,
                                 phi.formula_null = ~ DayAmdmt,
                                 test = "Wald", boot = FALSE,
                                 data = soil_phylum_small,
-                                fdr_cutoff = 0.05)
+                                fdr_cutoff = 0.05,
+                                try_only = 1:5)
 plot(da_analysis, level = "Phylum")
 
 }

--- a/vignettes/corncob-intro.Rmd
+++ b/vignettes/corncob-intro.Rmd
@@ -44,7 +44,7 @@ Note that in order to follow along with this tutorial (but not to use \texttt{co
 
 Install \texttt{corncob} using:
 ```{r, eval = FALSE}
-devtools::install_github("statdivlab/corncob")
+remotes::install_github("statdivlab/corncob")
 ```
 
 


### PR DESCRIPTION
replace mentions of the CRAN version of `corncob` and `install.packages("corncob")` with the Github version and `remotes::install_github("statdivlab/corncob")`