### PR TITLE
Update geom_errorbarh to geom_errorbar

### DIFF
--- a/R/plot_differentialTest.R
+++ b/R/plot_differentialTest.R
@@ -73,7 +73,7 @@ plot.differentialTest <- function(x, level = NULL, data_only = FALSE, ...) {
       ggplot2::geom_vline(xintercept = 0, color = "gray50", lty = "dashed",
                           alpha = 0.75, lwd = 1) +
       ggplot2::geom_point() +
-      ggplot2::geom_errorbarh(ggplot2::aes(xmin = xmin, xmax = xmax, colour = xmin<=0 & xmax <= 0| xmin>=0 & xmax >= 0), height = .3) +
+      ggplot2::geom_errorbar(ggplot2::aes(xmin = xmin, xmax = xmax, colour = xmin<=0 & xmax <= 0| xmin>=0 & xmax >= 0), height = .3, orientation = "x") +
       ggplot2::theme_bw() +
       ggplot2::facet_wrap(~variable, scales = "free_x", nrow = 1) +
       ggplot2::labs(title = "", x = "", y = "Taxa") +


### PR DESCRIPTION
Hi,

Thanks for all the work you do on corncob. 

I am busy attempting to implement TreeSummarizedExperiment support for corncob, in the process I noticed that tests were giving a warning due to the fact that plot.differentialTest was using `geom_errorbarh` which has been deprecated. This PR just updates the plot and all tests pass without issue now.